### PR TITLE
Feat: Add generic encode and decode 

### DIFF
--- a/src/coders/ecdsa-coder.ts
+++ b/src/coders/ecdsa-coder.ts
@@ -188,7 +188,7 @@ class Eip155TxCoder extends DefaultEcdsaTxCoder {
  * ctcCoder  *
  ************/
 
-function encode(data) {
+function encode(data: EIP155TxData): string {
   if (data.type === TxType.EIP155) {
     return new Eip155TxCoder().encode(data)
   }
@@ -198,7 +198,7 @@ function encode(data) {
   return null
 }
 
-function decode(data: string | Buffer) {
+function decode(data: string | Buffer): EIP155TxData {
   if (Buffer.isBuffer(data)) {
     data = data.toString()
   }

--- a/test/coders/batch-encoder.spec.ts
+++ b/test/coders/batch-encoder.spec.ts
@@ -84,26 +84,6 @@ describe('BatchEncoder', () => {
       expect(eip155TxData).to.deep.equal(decoded)
     })
 
-    it('should decode ETH_SIGN txs to the correct value', () => {
-      // TODO(annieke): use real ETH_SIGN transaction
-      const ethSignTxData = {
-        sig: {
-          v: 1,
-          r: '0x' + '11'.repeat(32),
-          s: '0x' + '22'.repeat(32),
-        },
-        gasLimit: 500,
-        gasPrice: 100,
-        nonce: 100,
-        target: '0x' + '12'.repeat(20),
-        data: '0x' + '99'.repeat(10),
-        type: TxType.EthSign,
-      }
-      const encoded = ctcCoder.encode(ethSignTxData)
-      const decoded = ctcCoder.decode(encoded)
-      expect(ethSignTxData).to.deep.equal(decoded)
-    })
-
     it('should return null when encoding an unknown type', () => {
       const weirdTypeTxData = {
         sig: {


### PR DESCRIPTION
This PR adds generic encode/decode functions to `ctcCoder`. It is a part of https://github.com/ethereum-optimism/roadmap/issues/614

## Breaking changes

- Adds`type` field to `DefaultEcdsaTxData`

### TODO

- [ ] Find specific tx for `ETH_SIGN` and add to unit test
- [x] Documentation? Could be in followup