### PR TITLE
[Testing] Add workflow for release and publish

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
+      - run: yarn build
       # - run: yarn publish
       - run: yarn publish --access restricted
         env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'
-      - 'beta*'
+      - '*-beta*'
 
 jobs:
   release:
@@ -29,11 +29,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
       - run: yarn build
       # - run: yarn publish
-      - run: yarn publish --access restricted
+      - run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,38 @@
+name: Create Releases and publish on Tags
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - 'beta*'
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/create-relase@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with: 
+          tag_name: ${{ github.ref }} 
+          release_name: ${{ github.ref }}
+          # draft: false
+          # prerelease: false
+
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn
+      # - run: yarn publish
+      - run: yarn publish --access restricted
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This workflow creates a release and publishes it whenever we have a tag that begins with `v` or `beta`. It uses a different release action from batch submitter (switched https://github.com/Roang-zero1/github-create-release-action to GH Action's official https://github.com/actions/create-release for better maintenance).

This workflow as is should only create draft and prereleases, as well as only publish with restricted access for testing purposes.

Addresses https://github.com/ethereum-optimism/roadmap/issues/624