### PR TITLE
build: turn on composite mode for core-utils

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "composite": true,
         "module": "commonjs",
         "target": "es2017",
         "declaration": true,


### PR DESCRIPTION
Composite mode is required by [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html), a very useful feature in TypeScript.