### PR TITLE
refactor: set base to null to avoid logging pid and hostname by default

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -49,6 +49,9 @@ export class Logger {
     pino({
       name: options.name,
 
+      // Remove pid and hostname considering production runs inside docker
+      base: null,
+
       // Pretty printing enabled by default to maintain expectations
       prettyPrint: {
         colorize: true,


### PR DESCRIPTION
Based on understanding of `base` object (see API docs: https://github.com/pinojs/pino/blob/master/docs/api.md#base-object)

Addresses comment: https://github.com/ethereum-optimism/data-transport-layer/pull/76#pullrequestreview-607709801

One thing to note is that it's not completely useless, `pid` will still be unique per container, right @tynes?
