### PR TITLE
refactor: remove basic ethereum constants from package

### DIFF
--- a/src/constants/eth-constants.ts
+++ b/src/constants/eth-constants.ts
@@ -1,3 +1,0 @@
-export const ZERO_ADDRESS = '0x' + '00'.repeat(20)
-export const ZERO_BYTES32 = '0x' + '00'.repeat(32)
-export const DEAD_ADDRESS = '0xdeaDDeADDEaDdeaDdEAddEADDEAdDeadDEADDEaD'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,0 @@
-export * from './eth-constants'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from './coders'
 export * from './common'
-export * from './constants'


### PR DESCRIPTION
In the spirit of minimalization, we do not need to be re-exporting ethereum constants. `ethers` offers `ethers.constants` which is useful for things like Zero and HashZero. 
