### PR TITLE
fix: Reset Math.random after tests

### DIFF
--- a/test/common/addresses.spec.ts
+++ b/test/common/addresses.spec.ts
@@ -6,11 +6,11 @@ import { getRandomAddress } from '../../src'
 describe('getRandomAddress', () => {
   const random = global.Math.random
 
-  beforeEach(async () => {
+  before(async () => {
     global.Math.random = () => 0.5
   })
 
-  afterEach(async () => {
+  after(async () => {
     global.Math.random = random
   })
 

--- a/test/common/addresses.spec.ts
+++ b/test/common/addresses.spec.ts
@@ -4,8 +4,14 @@ import { expect } from '../setup'
 import { getRandomAddress } from '../../src'
 
 describe('getRandomAddress', () => {
+  const random = global.Math.random
+
   beforeEach(async () => {
     global.Math.random = () => 0.5
+  })
+
+  afterEach(async () => {
+    global.Math.random = random
   })
 
   it('returns a random address string', () => {

--- a/test/common/hex-utils.spec.ts
+++ b/test/common/hex-utils.spec.ts
@@ -6,11 +6,11 @@ import { getRandomHexString } from '../../src'
 describe('getRandomHexString', () => {
   const random = global.Math.random
 
-  beforeEach(async () => {
+  before(async () => {
     global.Math.random = () => 0.5
   })
 
-  afterEach(async () => {
+  after(async () => {
     global.Math.random = random
   })
 

--- a/test/common/hex-utils.spec.ts
+++ b/test/common/hex-utils.spec.ts
@@ -4,8 +4,14 @@ import { expect } from '../setup'
 import { getRandomHexString } from '../../src'
 
 describe('getRandomHexString', () => {
+  const random = global.Math.random
+
   beforeEach(async () => {
     global.Math.random = () => 0.5
+  })
+
+  afterEach(async () => {
+    global.Math.random = random
   })
 
   it('returns a random address string of the specified length', () => {


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
`Math.random` was being mutated during our tests to provide consistent random values but was not being reset. Would mess with other tests that use `Math.random`.